### PR TITLE
[auto] Add OSS policy reference to social-sentinel CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ credentials.json
 # AI/LLM artifacts
 CLAUDE.md
 .ai/
+# cc-taskrunner worktree protection
+C:*
+node_modules/
+.pnpm-store/
+__pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,3 +116,16 @@ When PII is detected during redaction:
 - Sentiment text truncation: 500 characters (model token limit)
 - Sentiment batch concurrency: 10 requests (configurable in `analyzer.analyzeBatch()`)
 - Event ID prefix: `ss-` (Social Sentinel)
+
+## OSS Policy
+
+This is a **public infrastructure package** governed by the Stackbilt OSS Infrastructure Package Update Policy.
+
+Rules:
+1. **Additive only** — never remove or rename public API without a major version bump
+2. **No product logic** — framework patterns and generic utilities only. If a competitor could reconstruct Stackbilt product architecture from this code, it doesn't belong here.
+3. **Strict semver** — patch for fixes, minor for new features, major for breaking changes
+4. **Tests travel with code** — every public export must have test coverage
+5. **Validate at boundaries** — all external API responses validated before returning to consumers
+
+Full policy: `stackbilt_llc/policies/oss-infrastructure-update-policy.md`


### PR DESCRIPTION
## Autonomous Task

**Task ID**: `3ee42994-97ae-402a-8a4a-418d7d848434`
**Authority**: auto_safe
**Exit code**: 0

## Task Prompt
Add the following section to the end of CLAUDE.md (create the file if it doesn't exist). Do NOT modify any other content in the file.

## OSS Policy

This is a **public infrastructure package** governed by the Stackbilt OSS Infrastructure Package Update Policy.

Rules:
1. **Additive only** — never remove or rename public API without a major version bump
2. **No product logic** — framework patterns and generic utilities only. If a competitor could reconstruct Stackbilt product architecture from this code, it doesn't belong here.
3. **Strict semver** — patch for fixes, minor for new features, major for breaking changes
4. **Tests travel with code** — every public export must have test coverage
5. **Validate at boundaries** — all external API responses validated before returning to consumers

Full policy: `stackbilt_llc/policies/oss-infrastructure-update-policy.md`

Commit with message: "docs: add OSS policy reference to CLAUDE.md"

TASK_COMPLETE

## Result Summary
OSS Policy section appended to CLAUDE.md and committed.

TASK_COMPLETE

---
Generated by AEGIS task runner. Review before merging.